### PR TITLE
Add interactive user elicitation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ where:
 * `--pool_diversity_num_clusters` refers to the number of clusters we use for pool-based active learning with diversity sampling.
 * `--task` refers to which domain we are evaluating (content recommendation, moral reasoning, email validation).
 
+
+### Manual preference elicitation
+You can also act as the elicitation agent yourself while the language model simulates a human persona. This is useful for comparing your own questioning strategies to those produced by an LM.
+
+```bash
+python run_user_elicitation.py \
+    --engine <engine> \
+    --task [website_preferences|moral_reasoning|email_regex]
+```
+
+The script randomly selects a persona for the chosen task from `gpt_prompts/`. It lets you converse with the simulated human and reports evaluation metrics after each turn.

--- a/interactive_user_agent.py
+++ b/interactive_user_agent.py
@@ -1,0 +1,20 @@
+from base_active_learning_agent import BaseActiveLearningAgent
+
+class InteractiveUserAgent(BaseActiveLearningAgent):
+    """Active learning agent that takes queries from a human user."""
+
+    def __init__(self, target_specification_file, engine, openai_cache_file=None, **kwargs):
+        super().__init__(target_specification_file, engine, openai_cache_file, **kwargs)
+
+    def get_hypothesis_prompt(self, interaction_history, broken_regexes=None):
+        # Not used for interactive mode
+        pass
+
+    def generate_active_query(self):
+        # Queries are provided by the user via input
+        return None
+
+    def generate_oracle_response(self, query):
+        answer = self.query_oracle_api(query, None)
+        self.interaction_history.append((query, answer))
+        return answer

--- a/run_user_elicitation.py
+++ b/run_user_elicitation.py
@@ -1,0 +1,99 @@
+import glob
+import json
+import os
+import random
+from copy import deepcopy
+
+from tap import Tap
+from tqdm import tqdm
+
+from interactive_user_agent import InteractiveUserAgent
+from utils import update_metrics, update_test_responses
+
+
+def run_user_problem_instance(
+    problem_instance_filename,
+    engine,
+    openai_cache_file,
+    num_interactions,
+    temperature=0.0,
+    outputs_save_file=None,
+):
+    """Runs an interactive elicitation session where a human queries an LLM."""
+    agent = InteractiveUserAgent(
+        problem_instance_filename,
+        engine,
+        openai_cache_file=openai_cache_file,
+        temperature=temperature,
+    )
+
+    if outputs_save_file:
+        outputs_save_file.write(f"0. {agent.persona}\n\n")
+
+    test_xs = agent.get_interaction_features()
+    test_score, test_responses = agent.score_test_cases()
+    print(test_score)
+    all_test_xs = update_metrics({}, test_xs)
+    test_scores = update_metrics({}, test_score)
+    start_test_scores = deepcopy(test_scores)
+    all_test_responses = update_test_responses([], test_responses)
+
+    for i in tqdm(range(num_interactions)):
+        query = input("Your question (or 'quit' to exit): ")
+        if query.strip().lower() in {"quit", "exit", "stop"}:
+            break
+        answer = agent.generate_oracle_response(query)
+        print("Model:", answer)
+        if outputs_save_file:
+            outputs_save_file.write(f"{i}. {query}\n{answer}\n\n")
+
+        test_xs = agent.get_interaction_features()
+        test_score, test_responses = agent.score_test_cases(start_metrics=start_test_scores)
+        print(test_score)
+        all_test_xs = update_metrics(all_test_xs, test_xs)
+        test_scores = update_metrics(test_scores, test_score)
+        all_test_responses = update_test_responses(all_test_responses, test_responses)
+
+    if outputs_save_file:
+        outputs_save_file.write(
+            f"===TEST RESPONSES===\n{json.dumps(all_test_responses, indent=2)}\n\n"
+        )
+
+    return all_test_xs, test_scores
+
+
+def main(args):
+    if args.no_cache:
+        openai_cache_file = None
+    else:
+        openai_cache_file = f"{args.engine}-cache-seed-{args.seed}.jsonl"
+
+    problem_instance_filename = random.choice(glob.glob(f"gpt_prompts/{args.task}/*.json"))
+    os.makedirs(f"user_model_results/{args.task}", exist_ok=True)
+    outputs_save_file = open(
+        f"user_model_results/{args.task}/{args.engine}_{args.seed}.txt",
+        "w",
+    )
+
+    run_user_problem_instance(
+        problem_instance_filename=problem_instance_filename,
+        engine=args.engine,
+        openai_cache_file=openai_cache_file,
+        num_interactions=args.num_interactions,
+        temperature=args.temperature,
+        outputs_save_file=outputs_save_file,
+    )
+
+
+class ArgumentParser(Tap):
+    num_interactions: int = 5
+    engine: str = "gpt-4"
+    task: str = "email_regex"
+    no_cache: bool = False
+    seed: int = 0
+    temperature: float = 0.0
+
+
+if __name__ == "__main__":
+    args = ArgumentParser().parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- add a minimal `InteractiveUserAgent` for human-driven queries
- create `run_user_elicitation.py` to talk with a persona-simulated LLM
- document new script in README

## Testing
- `python -m py_compile run_user_elicitation.py interactive_user_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a6a184d8832eac4495712baf647a