### PR TITLE
Add question mode selection to model evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ python run_model_evaluation.py \
     --agent [questions|edge_cases|pool] \
     --eval_condition [per_turn|per_minute|at_end] \
     --pool_diversity_num_clusters <pool_diversity_num_clusters> \
+    --question_modes <mode1> [mode2 ...] \
     --task [website_preferences|moral_reasoning|email_regex] \
 ```
 
@@ -85,6 +86,7 @@ where:
 * `--eval_condition` refers to how often we produce evaluate the intermediate results of each transcript, with `per_turn` meaning we evaluate the transcript after each turn, `per_minute` meaning we evaluate the transcript only after each minute of interaction, and `at_end` meaning we only evaluate the transcript at the very end.
 * `--pool_diversity_num_clusters` refers to the number of clusters we use for pool-based active learning with diversity sampling.
 * `--task` refers to which domain we are evaluating (content recommendation, moral reasoning, email validation).
+* `--question_modes` allows specifying which question modes to run (e.g. `questions_open`, `edge_cases`). If omitted, all modes for the task are evaluated.
 
 
 ### Manual preference elicitation

--- a/run_model_evaluation.py
+++ b/run_model_evaluation.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import glob
+from typing import List, Optional
 
 import numpy as np
 from tap import Tap
@@ -119,8 +120,17 @@ def main(args):
         'correct_prob_relative', 'question_mode', 'task', 'engine', 'seed',
     ])
 
-    if args.task == "website_preferences":
-        question_modes = ["questions_open", "questions_yn", "edge_cases", "pool_diversity", "pool_random", "pool_uncertainty_logits"]
+    if args.question_modes is not None and len(args.question_modes) > 0:
+        question_modes = args.question_modes
+    elif args.task == "website_preferences":
+        question_modes = [
+            "questions_open",
+            "questions_yn",
+            "edge_cases",
+            "pool_diversity",
+            "pool_random",
+            "pool_uncertainty_logits",
+        ]
     else:
         question_modes = ["questions_open", "questions_yn", "edge_cases"]
     
@@ -129,6 +139,7 @@ def main(args):
     for question_mode in question_modes:
         avg_test_scores[question_mode] = {}
         print(question_mode)
+        question_type = "open"
 
         for problem_instance_filename in tqdm(glob.glob(f"gpt_prompts/{args.task}/*.json")):
 
@@ -186,6 +197,7 @@ class ArgumentParser(Tap):
     no_cache: bool = False  # Whether to use the OpenAI cache file.
     seed: int = 0  # The random seed to use.
     temperature: float = 0.0  # The temperature to use for the model.
+    question_modes: Optional[List[str]] = None  # Question mode(s) to evaluate. Defaults depend on task.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow passing `--question_modes` to `run_model_evaluation.py`
- document question mode argument in README

## Testing
- `python -m py_compile run_model_evaluation.py`

------
https://chatgpt.com/codex/tasks/task_e_6859743cc924832e9a43c6dba9271843